### PR TITLE
CLIコマンドの実装を拡張可能にした + オプションへの依存内容を明示的にした

### DIFF
--- a/src/build/template.ts
+++ b/src/build/template.ts
@@ -1,0 +1,4 @@
+export interface Template {
+  text: string
+  filePath: string
+}

--- a/src/buildTemplate.ts
+++ b/src/buildTemplate.ts
@@ -2,8 +2,9 @@ import fs from 'fs'
 import path from 'path'
 import template from './template'
 import createTemplateValues from './createTemplateValues'
+import { Template } from './build/template'
 
-export default (input: string, baseURL = '') => {
+export default (input: string, baseURL = ''): Template => {
   const { api, imports } = createTemplateValues(input)
   const hasTypes =
     fs.existsSync(path.join(input, '@types')) || fs.existsSync(path.join(input, '@types.ts'))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,10 +34,12 @@ export const run = (args: string[]) => {
     watch(input, () => {
       const result = build(input, argv.baseurl)
 
-      if (prevResult.text !== result.text || prevResult.filePath !== result.filePath) {
-        fs.unlink(prevResult.filePath, () => write(result))
-        prevResult = result
+      if (prevResult.text === result.text && prevResult.filePath !== result.filePath) {
+        return
       }
+
+      fs.unlink(prevResult.filePath, () => write(result))
+      prevResult = result
     })
   })
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import getConfig, { Config } from './getConfig'
 import read from './getInputs'
 import write from './writeRouteFile'
 import watch from './watchInputDir'
-import { Build, Watch, BuildCommandFactory } from './cli/build'
+import { Build, Watch, CommandToBuild } from './cli/build'
 import { Command, nullCommand } from './cli/command'
 import { version as versionCommand } from './cli/version'
 
@@ -14,7 +14,7 @@ const options: minimist.Opts = {
 }
 
 const getBuildCommandFactory = (config: Config) =>
-  BuildCommandFactory.getFactory(config, {
+  CommandToBuild.getFactory(config, {
     read,
     write,
     watch,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,21 +19,25 @@ export const run = (args: string[]) => {
     console.log(`v${require('../package').version}`)
   }
 
-  if (argv.build !== undefined || argv.watch !== undefined) {
-    getInputs(config.input).forEach(input => {
-      let prevResult = build(input, argv.baseurl)
-      write(prevResult)
+  if (argv.build === undefined && argv.watch === undefined) {
+    return
+  }
 
-      if (argv.watch !== undefined) {
-        watch(input, () => {
-          const result = build(input, argv.baseurl)
+  getInputs(config.input).forEach(input => {
+    let prevResult = build(input, argv.baseurl)
+    write(prevResult)
 
-          if (prevResult.text !== result.text || prevResult.filePath !== result.filePath) {
-            fs.unlink(prevResult.filePath, () => write(result))
-            prevResult = result
-          }
-        })
+    if (argv.watch === undefined) {
+      return
+    }
+
+    watch(input, () => {
+      const result = build(input, argv.baseurl)
+
+      if (prevResult.text !== result.text || prevResult.filePath !== result.filePath) {
+        fs.unlink(prevResult.filePath, () => write(result))
+        prevResult = result
       }
     })
-  }
+  })
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import getConfig from './getConfig'
 import read from './getInputs'
 import write from './writeRouteFile'
 import watch from './watchInputDir'
-import { Build, Watch, CommandRunner } from './cli/build'
+import { Build, Watch, BuildCommandRunner } from './cli/build'
 
 const options: minimist.Opts = {
   string: ['version', 'config', 'build', 'watch', 'baseurl'],
@@ -25,7 +25,7 @@ export const run = (args: string[]) => {
 
   const buildCommand = argv.watch === undefined ? new Build(argv.baseurl) : new Watch(argv.baseurl)
 
-  const buildCommandRunner = new CommandRunner(buildCommand, config, {
+  const buildCommandRunner = new BuildCommandRunner(buildCommand, config, {
     read,
     write,
     watch,

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -3,11 +3,11 @@ import build from '../buildTemplate'
 import { Template } from '../build/template'
 import { Command } from './command'
 
-export class BuildCommandFactory implements Command {
+export class CommandToBuild implements Command {
   static getFactory(config: Config, io: BuildIO) {
     return {
       create(command: BuildCommand): Command {
-        return new BuildCommandFactory(command, config, io)
+        return new CommandToBuild(command, config, io)
       }
     }
   }

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,19 +1,9 @@
 import { Config } from '../getConfig'
 import build from '../buildTemplate'
 import { Template } from '../build/template'
+import { Command } from './command'
 
-interface BuildCommand {
-  run(input: string, io: BuildIO): void
-}
-
-export interface BuildIO {
-  read(input?: string | string[]): string[]
-  write(template: Template): void
-  remove(filePath: string, callback: () => void): void
-  watch(input: string, callback: () => void): void
-}
-
-export class CommandRunner {
+export class BuildCommandRunner implements Command {
   // eslint-disable-next-line no-useless-constructor
   constructor(
     private readonly command: BuildCommand,
@@ -26,6 +16,17 @@ export class CommandRunner {
       this.command.run(input, this.io)
     })
   }
+}
+
+interface BuildCommand {
+  run(input: string, io: BuildIO): void
+}
+
+export interface BuildIO {
+  read(input?: string | string[]): string[]
+  write(template: Template): void
+  remove(filePath: string, callback: () => void): void
+  watch(input: string, callback: () => void): void
 }
 
 export class Build implements BuildCommand {

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -3,9 +3,17 @@ import build from '../buildTemplate'
 import { Template } from '../build/template'
 import { Command } from './command'
 
-export class BuildCommandRunner implements Command {
+export class BuildCommandFactory implements Command {
+  static getFactory(config: Config, io: BuildIO) {
+    return {
+      create(command: BuildCommand): Command {
+        return new BuildCommandFactory(command, config, io)
+      }
+    }
+  }
+
   // eslint-disable-next-line no-useless-constructor
-  constructor(
+  private constructor(
     private readonly command: BuildCommand,
     private readonly config: Config,
     private readonly io: BuildIO

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,0 +1,57 @@
+import { Config } from '../getConfig'
+import build from '../buildTemplate'
+import { Template } from '../build/template'
+
+interface BuildCommand {
+  run(input: string, io: BuildIO): void
+}
+
+export interface BuildIO {
+  read(input?: string | string[]): string[]
+  write(template: Template): void
+  remove(filePath: string, callback: () => void): void
+  watch(input: string, callback: () => void): void
+}
+
+export class CommandRunner {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(
+    private readonly command: BuildCommand,
+    private readonly config: Config,
+    private readonly io: BuildIO
+  ) {}
+
+  exec() {
+    this.io.read(this.config.input).forEach(input => {
+      this.command.run(input, this.io)
+    })
+  }
+}
+
+export class Build implements BuildCommand {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private readonly baseUrl: string) {}
+
+  run(input: string, io: BuildIO): void {
+    const template = build(input, this.baseUrl)
+
+    io.write(template)
+  }
+}
+export class Watch implements BuildCommand {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(
+    private readonly baseUrl: string,
+    private readonly build: Build = new Build(baseUrl)
+  ) {}
+
+  run(input: string, io: BuildIO): void {
+    this.build.run(input, io)
+
+    io.watch(input, () => {
+      const result = build(input, this.baseUrl)
+
+      io.remove(result.filePath, () => io.write(result))
+    })
+  }
+}

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -1,0 +1,3 @@
+export interface Command {
+  exec(): void
+}

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -1,3 +1,9 @@
 export interface Command {
   exec(): void
 }
+
+export const nullCommand: Command = {
+  exec() {
+    // nothing to do
+  }
+}

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,7 @@
+import { Command } from './command'
+
+export const version: Command = {
+  exec() {
+    console.log(`v${require('../../package.json').version}`)
+  }
+}

--- a/src/writeRouteFile.ts
+++ b/src/writeRouteFile.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
+import { Template } from './build/template'
 
-export default ({ filePath, text }: { filePath: string; text: string }) => {
+export default ({ filePath, text }: Template) => {
   fs.writeFileSync(filePath, text, 'utf8')
   console.log(`${filePath} was built successfully.`)
 }


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->
Issue Number: N/A

<!--- Describe your changes in detail. -->
開発者が `cli.ts` を見る動機としては
- どのようなコマンド引数/オプションが用意されているか
- 引数/オプションを指定すると、どのような処理が行われるか
- 指定した引数/オプションはどのように利用されているか

を確認したいという意図が有ると考えた。
また、今後aspidaの機能が拡張されるに従ってサポートするコマンドの種類が増えてきた時にcli.tsの肥大化を最低限に抑えられる構造を用意しておきたいと考えた。

上記の理由から
- `Command` インタフェースを定義し、コマンド内容は個別のコマンドオブジェクトとして定義
    - `cli.ts` からは、コマンドオブジェクトを生成〜メソッド呼び出しすれば良いようにする狙い
    - 具体的なコマンドの処理内容を知りたければ、それぞれのコマンドオブジェクトの実装を確認すれば良いようにする狙い
- `cli.ts` では、オプションの指定状況とコマンドオブジェクトの対応関係を記述
    - どのオプションを指定するとどのコマンドが実行されるのか、一覧しやすいようにする狙い
    - どのオプションを指定するとどのコマンドに影響するのか、一覧しやすいようにする狙い
    - 逆に、あるコマンドを実行するにはどのオプション指定が必要か、一覧しやすいようにする狙い
- 各コマンドオブジェクトの実行を、シンプルなループ処理で実行するようにした
    - 今後サポートするコマンドが増えた場合も、新たに定義したコマンドオブジェクトを配列に追加すれば良い
    - 実体は単なるループなので、必要に応じて非同期化も可能

といったリファクタを行った。